### PR TITLE
Add eslintrc configuration to ignore unused next() argument in Express middleware

### DIFF
--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -5,6 +5,7 @@
     "object-curly-spacing": ["warn", "never"],
     "func-names": "off",
     "space-before-function-paren": ["error", "never"],
-    "max-len": ["error", 120, 4]
+    "max-len": ["error", 120, 4],
+    "no-unused-vars": ["error", {"argsIgnorePattern": "next"}]
   }
 }

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -22,7 +22,7 @@ app.get('/', (req, res) => {
 });
 
 // catch all unhandled errors
-app.use((err, req, res, next) => { // eslint-disable-line
+app.use((err, req, res, next) => {
   logger.error('unhandled application error: ', err);
   res.status(500).send(err);
 });


### PR DESCRIPTION
Express middleware that does not end the request-response cycle must call next() to pass control to the next middleware function.  Error-handler middleware, in particular, always takes four arguments including next().  Since next is being defined as an argument and eslint does not detect its use an unused-vars error will be reported.  To avoid this and to keep from having to litter the project code with eslint-disable-line comments a rule is being added to .eslintrc to ignore the unused "next" argument.