### PR TITLE
Rewrite npm Docker scripts in JavaScript to make them run on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 server/db/
+npm-debug.log

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "db:start": "docker run -d -p 28015:28015 -p 8090:8080 -v $PWD/db:/data --name expertsdb rethinkdb",
+    "db:start": "node util/db/start",
     "db:stop": "docker stop expertsdb",
     "db:rm": "docker rm expertsdb",
     "test": "eslint src/ && node test/index.js | tap-spec"

--- a/server/util/db/start.js
+++ b/server/util/db/start.js
@@ -1,0 +1,34 @@
+/* eslint no-console: 0 */
+
+// node module
+const exec = require('child_process').exec;
+const path = require('path');
+
+// dir to store the data in
+const dbPath = path.join(__dirname, '..', '..', 'db');
+
+// docker run command
+const cmd = `docker run -d -p 28015:28015 -p 8090:8080 -v ${dbPath}:/data --name expertsdb rethinkdb`;
+
+// execute command
+const start = exec(cmd);
+
+// remember if docker is installing image
+let dbImage = false;
+
+// runs when command writes to stdout
+start.stdout.on('data', (data) => {
+  if (data) {
+    console.log('Sucessfully created expertsdb\n');
+  }
+});
+
+// runs when command writes to stderr
+start.stderr.on('data', (data) => {
+  if (data === "Unable to find image 'rethinkdb:latest' locally\n" || dbImage) {
+    console.log(data);
+    dbImage = true;
+  } else {
+    console.log('Error while creating expertsdb:', data);
+  }
+});


### PR DESCRIPTION
The current npm script to start the database docker image fails on Windows, due to lack of support for `$PWD`.
To resolve this i have rewritten the db:* scripts in JavaScript, where i have used Node's `path` module to substitute `$PWD`, and `child_process.exec()` to run the command in a shell. This is also a more precise way to do it, than using `$PWD`, as it is possible to run `npm run db:start` from a different directory than `/server`, which would result in the `db/` folder being created in an unintended directory. This will not be possible with my implementation.