### PR TITLE
Fix: user.data value is stored as string in localStorage

### DIFF
--- a/client/src/store/reducers/auth.js
+++ b/client/src/store/reducers/auth.js
@@ -3,7 +3,7 @@ import * as ActionTypes from '../actionTypes';
 
 const initialState = {
   token: localStorage.getItem('user.token'),
-  user: localStorage.getItem('user.data'),
+  user: JSON.parse(localStorage.getItem('user.data')),
 };
 
 export const auth = (state = initialState, action) => {
@@ -14,7 +14,7 @@ export const auth = (state = initialState, action) => {
       };
     case ActionTypes.LOGIN_SUCCESS:
       localStorage.setItem('user.token', action.payload.token);
-      localStorage.setItem('user.data', action.payload.user);
+      localStorage.setItem('user.data', JSON.stringify(action.payload.user));
       return {
         ...action.payload,
       };


### PR DESCRIPTION
localStorage seems to be limited to handle only string key/value pairs. See: http://stackoverflow.com/questions/2010892/storing-objects-in-html5-localstoragewq